### PR TITLE
New CLI branch based off updated master

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,18 @@
+## CLI for BatChain P2P File Storage
+
+## Same CLI feature as node.js
+
+### Demo for sample:
+1. Type `batchain sample` to create server for node1
+2. Open another terminal window, select the options to upload/download files while connecting to node1
+  - `batchain sample -u <filePath>`:
+    `batchain sample -u './personal/example.txt'``
+  - `batchain sample -d <manifestFile>`
+3. If your server window keeps running, you can view your current uploaded lists in another window
+  - `batchain -l`
+4. You can always run `batchain -h` to review the available command and options
+
+## Note:
+1. Before run any `batchain` option or command, make sure to run `npm install -g`
+2. Need to run `npm install -g` when making bin changes
+3. If "chalk" is not working for you, run `npm insatll chalk --save` to make the command line more colorful

--- a/bin/batnode-sample.js
+++ b/bin/batnode-sample.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const bat_sample = require('commander');
+const chalk = require('chalk');
+const ProgressBar = require('progress');
+
+const BatNode = require('../batnode').BatNode;
+const PERSONAL_DIR = require('../utils/file').PERSONAL_DIR;
+const HOSTED_DIR = require('../utils/file').HOSTED_DIR;
+const fileSystem = require('../utils/file').fileSystem;
+const fs = require('fs');
+
+bat_sample
+  .description("Demo connection")
+  .option('-u, --upload <filePath>', 'upload files from specified file path')
+  .option('-d, --download <manifestPath>', 'retrieve files from manifest file path')
+  .parse(process.argv);
+
+console.log(chalk.bold.magenta("Hello, welcome to batchain!"));
+
+const node1 = new BatNode();
+node1.port = 1237;
+node1.host = '127.0.0.1';
+
+if (bat_sample.upload) {
+  console.log(chalk.yellow('sample node2 uploads files to sample node1'));
+
+  // process file upload in the specified path('../encrypt/orgexp.txt');
+  const node2 = new BatNode();
+
+  node2.uploadFile(node1.port, node1.host, bat_sample.upload);
+
+  // node2.retrieveFile('example.txt.crypt', 1237, '127.0.0.1')
+} else if (bat_sample.download) {
+  console.log(chalk.yellow('sample node2 downloads files from sample node1'));
+  const node2 = new BatNode();
+  node2.retrieveFile(bat_sample.download, node1.port, node1.host, function() {
+    console.log("File download and decrypt complete");
+  });
+
+} else {
+  runSampleNode();
+}
+
+
+// Define callback for server to execute when a new connection has been made.
+// The connection object can have callbacks defined on it
+// Below is a node server that can respond to file retrieval requests or file storage requests
+
+// When sending image data as part of JSON object, two JSON objects are sent, each sending an incomplete JSON object
+// with only part of the image data
+function runSampleNode() {
+  const node1ConnectionCallback = (serverConnection) => {
+    serverConnection.on('data', (receivedData, error) => {
+    // console.log("received data: ", receivedData)
+      receivedData = JSON.parse(receivedData);
+      //console.log(receivedData, "FROM SERVER")
+
+      if (receivedData.messageType === "RETRIEVE_FILE") {
+        node1.readFile(`./hosted/${receivedData.fileName}`, (error, data) => {
+        serverConnection.write(data)
+        })
+      } else if (receivedData.messageType === "STORE_FILE"){
+        node1.receiveFile(receivedData)
+        serverConnection.write(JSON.stringify({messageType: "SUCCESS"}))
+      }
+    })
+  }
+
+  console.log(chalk.bgBlue("Start sample node1 server"));
+  node1.createServer(1237,'127.0.0.1', node1ConnectionCallback, null)
+  //fileSystem.processUpload('../personal/example.txt')
+  //fileSystem.composeShards('../manifest/4f112a6ec12a710bc3cc4fba8d334ab09f87e2c4.batchain') //results in a decrypted-example.txt saved to personal dir
+
+}

--- a/bin/batnode-sample.js
+++ b/bin/batnode-sample.js
@@ -24,6 +24,10 @@ const node1 = new BatNode();
 node1.port = 1237;
 node1.host = '127.0.0.1';
 
+const node3 = new BatNode();
+node3.port = 1238;
+node3.host = '127.0.0.1';
+
 if (bat_sample.upload) {
   console.log(chalk.yellow('sample node2 uploads files to sample node1'));
 
@@ -71,6 +75,8 @@ function runSampleNode() {
 
   console.log(chalk.bgBlue("Start sample node1 server"));
   node1.createServer(1237,'127.0.0.1', node1ConnectionCallback, null)
+
+  node3.createServer(1238,'127.0.0.1', node1ConnectionCallback, null
   //fileSystem.processUpload('../personal/example.txt')
   //fileSystem.composeShards('../manifest/4f112a6ec12a710bc3cc4fba8d334ab09f87e2c4.batchain') //results in a decrypted-example.txt saved to personal dir
 

--- a/bin/batnode-sample.js
+++ b/bin/batnode-sample.js
@@ -40,13 +40,13 @@ if (bat_sample.upload) {
   node2.uploadFile(bat_sample.upload);
 
 } else if (bat_sample.download) {
-  console.log(chalk.yellow('sample node2 downloads files from sample node1'));
+  console.log(chalk.yellow('sample node2 downloads files from sample node1/node3'));
   const node2 = new BatNode();
   
   // retrieve file from one node: node2.retrieveFile('example.txt.crypt', 1237, '127.0.0.1')
-  node2.retrieveFile(bat_sample.download, node1.port, node1.host, function() {
-    console.log("File download and decrypt complete");
-  });
+  // node2.retrieveFileFromOneNode(bat_sample.download, node1.port, node1.host, function() {
+  //   console.log("File download and decrypt complete");
+  // });
   
   // retrieve file from nodes
   node2.retrieveFile(bat_sample.download);
@@ -80,7 +80,7 @@ function runSampleNode() {
     })
   }
 
-  console.log(chalk.bgBlue("Start sample node1/node3 server"));
+  console.log("Start sample node1/node3 server");
   node1.createServer(1237,'127.0.0.1', node1ConnectionCallback, null)
 
   node3.createServer(1238,'127.0.0.1', node1ConnectionCallback, null)

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const batchain = require('commander');
+const chalk = require('chalk');
+
+const BatNode = require('../batnode').BatNode;
+const PERSONAL_DIR = require('../utils/file').PERSONAL_DIR;
+const HOSTED_DIR = require('../utils/file').HOSTED_DIR;
+const fileSystem = require('../utils/file').fileSystem;
+
+batchain
+  .command('sample', 'see the sample nodes running')
+  .option('-l, --list', 'view your list of uploaded files in BatChain network')
+  .parse(process.argv);
+
+if (batchain.list) {
+  console.log(chalk.bold.cyan("You current file list: "));
+  const fs = require('fs');
+  const manifestFolder = './manifest/';
+
+  fs.readdirSync(manifestFolder).forEach(file => {
+    const manifestFilePath = manifestFolder + file;
+    const manifest = fileSystem.loadManifest(manifestFilePath);
+    console.log('name: ' + manifest.fileName + '; manifest path: ' + manifestFilePath);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,14 @@
 {
+  "name": "batchain",
+  "version": "1.0.0",
+  "description": "p2p storage solution",
+  "bin": {
+    "batchain": "bin/index.js",
+    "batchain-sample": "bin/batnode-sample.js"
+  },
   "dependencies": {
     "@kadenceproject/kadence": "^3.1.2",
+    "chalk": "^2.3.2",
     "dotenv": "^5.0.1",
     "public-ip": "^2.4.0"
   }


### PR DESCRIPTION
Brand new branch, should be able to merge now @dylankb @WilfredTA 

Currently I can only connect the `bin` section with `npm insatll -g` instead of `yarn`. There will be a lot of deprecation warnings after you run `npm install -g` but you can ignore them.

If you run into error with `chalk`, probably because the package is not installed properly. In that case, just simply run `npm install chalk --save` or `yarn add chalk` to install it.

Forgot to mention, if you really want to do a quick demonstration, may need to add below function expression back to "batnode.js":

```
// Send shards one at a time to only one node
  sendShardsToOneNode(port, host, shards){
    let shardIdx = 0
    let client = this.connect(port, host)

    client.on('data', (data) => {
      let serverResponse = JSON.parse(data).messageType
      console.log("Processing shard number: " + (shardIdx+1));
      if (shardIdx >= shards.length - 1){
        client.end();
      } else if (serverResponse === "SUCCESS" && shardIdx < shards.length - 1) {
        shardIdx += 1
        let message = {
          messageType: "STORE_FILE",
          fileName: shards[shardIdx],
          fileContent: fs.readFileSync(`./shards/${shards[shardIdx]}`)
        }
        client.write(JSON.stringify(message))
      }
    })

    let message = {
      messageType: "STORE_FILE",
      fileName: shards[shardIdx],
      fileContent: fs.readFileSync(`./shards/${shards[shardIdx]}`)
    }
    
    client.write(JSON.stringify(message))
    
    client.on('end', () => {
      console.log('upload end')
    })
  }
```

Then make sure in `fileUtils.processUpload(filePath, (manifestPath) => {` under `uploadFile(port, host, filePath) {`, call `this.sendShardsToOneNode(port, host, shardsOfManifest);` instead