### PR TITLE
CLI for local audit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,10 +202,11 @@ You can then uncomment the `retrieveFile` line in node3.js, but replace the mani
     5. `node clinode3.js`
     
 2. Open another(4th) terminal window, make sure your new window is in `kad-bat-plugin/node3`, otherwise the system can't verify the correct file path for you if you don't go to the client's directory.
-Then select the options to upload/download files while connecting to node1
-  - `batchain-sample -u <filePath>`:
+Then select the options to upload/download/audit files while connecting to node1
+  - Upload: `batchain-sample -u <filePath>`:
     `batchain-sample -u './personal/example.txt'`
-  - `batchain-sample -d <manifestFile>`(make sure don't modify the db folders under node1~3) 
+  - Download: `batchain-sample -d <manifestFile>`(make sure don't modify the db folders under node1~3) 
+  - Audit: `batchain-sample -a <manifestFile>`(make sure don't modify the db folders under node1~3)
 3. If your server window keeps running, you can view your current uploaded lists in another window
   - `batchain -l`
 4. You can always run `batchain -h` to review available command and options

--- a/bin/batnode-sample.js
+++ b/bin/batnode-sample.js
@@ -5,12 +5,11 @@
 const bat_sample = require('commander');
 const chalk = require('chalk');
 
+const BatNode = require('../batnode').BatNode;
 const PERSONAL_DIR = require('../utils/file').PERSONAL_DIR;
 const HOSTED_DIR = require('../utils/file').HOSTED_DIR;
 const fileSystem = require('../utils/file').fileSystem;
 const fs = require('fs');
-
-const BatNode = require('../kad-bat-plugin/batnode.js').BatNode;
   
 bat_sample
   .description("Demo connection for kad nodes and bat nodes")

--- a/bin/batnode-sample.js
+++ b/bin/batnode-sample.js
@@ -5,17 +5,18 @@
 const bat_sample = require('commander');
 const chalk = require('chalk');
 
-// const BatNode = require('../batnode').BatNode;
-const BatNode = require('../kad-bat-plugin/batnode.js').BatNode;
 const PERSONAL_DIR = require('../utils/file').PERSONAL_DIR;
 const HOSTED_DIR = require('../utils/file').HOSTED_DIR;
 const fileSystem = require('../utils/file').fileSystem;
 const fs = require('fs');
 
+const BatNode = require('../kad-bat-plugin/batnode.js').BatNode;
+  
 bat_sample
   .description("Demo connection for kad nodes and bat nodes")
   .option('-u, --upload <filePath>', 'upload files from specified file path')
   .option('-d, --download <manifestPath>', 'retrieve files from manifest file path')
+  .option('-a, --audit <manifestPath>', 'audit files from manifest file path')
   .parse(process.argv);
 
 const cliNode = new BatNode();
@@ -37,6 +38,18 @@ function sendDownloadMessage() {
     messageType: "CLI_DOWNLOAD_FILE",
     filePath: bat_sample.download,
   };
+        
+  client.write(JSON.stringify(message));
+}
+
+function sendAuditMessage() {
+  
+  const message = {
+    messageType: "CLI_AUDIT_FILE",
+    filePath: bat_sample.audit,
+  };
+  
+  console.log("message: ", message);
         
   client.write(JSON.stringify(message));
 }
@@ -64,5 +77,20 @@ if (bat_sample.upload) {
     console.log(chalk.yellow('sample node3 downloads files from sample node1/node2'));
     sendDownloadMessage();
   }
-
-} 
+  
+} else if (bat_sample.audit) {
+  client = cliNode.connect(1800, 'localhost');
+  
+  console.log(chalk.yellow('You can audit file to make sure file integrity'));
+  
+  if (!fs.existsSync(bat_sample.audit)) {
+    console.log(chalk.red('You entered an invalid manifest path, please enter a valid file and try again'));   
+  } else {
+    console.log(chalk.yellow('sample node3 audits files from sample node1/node2'));
+    sendAuditMessage();
+  }
+  
+} else {
+  console.log(chalk.bold.magenta("Welcome to Batchain demo"));
+  console.log(chalk.bold.magenta("Please make sure you have started the server"));
+}

--- a/bin/index.js
+++ b/bin/index.js
@@ -98,7 +98,7 @@ if (batchain.list) {
     sendDownloadMessage();
   }
 
-} else if (bat_sample.audit) {
+} else if (batchain.audit) {
   client = cliNode.connect(1800, 'localhost');
   
   console.log(chalk.yellow('You can audit file to make sure file integrity'));

--- a/bin/index.js
+++ b/bin/index.js
@@ -16,6 +16,7 @@ batchain
   .option('-l, --list', 'view your list of uploaded files in BatChain network')
   .option('-u, --upload <filePath>', 'upload files from specified file path')
   .option('-d, --download <manifestPath>', 'retrieve files from manifest file path')
+  .option('-a, --audit <manifestPath>', 'audit files from manifest file path')
   .parse(process.argv);
 
 const cliNode = new BatNode();
@@ -37,6 +38,18 @@ function sendDownloadMessage() {
     messageType: "CLI_DOWNLOAD_FILE",
     filePath: batchain.download,
   };
+        
+  client.write(JSON.stringify(message));
+}
+
+function sendAuditMessage() {
+  
+  const message = {
+    messageType: "CLI_AUDIT_FILE",
+    filePath: bat_sample.audit,
+  };
+  
+  console.log("message: ", message);
         
   client.write(JSON.stringify(message));
 }
@@ -85,6 +98,17 @@ if (batchain.list) {
     sendDownloadMessage();
   }
 
+} else if (bat_sample.audit) {
+  client = cliNode.connect(1800, 'localhost');
+  
+  console.log(chalk.yellow('You can audit file to make sure file integrity'));
+  
+  if (!fs.existsSync(bat_sample.audit)) {
+    console.log(chalk.red('You entered an invalid manifest path, please enter a valid file and try again'));   
+  } else {
+    console.log(chalk.yellow('sample node3 audits files from sample node1/node2'));
+    sendAuditMessage();
+  }
 } else {  
   console.log(chalk.bold.magenta("Hello, welcome to Batchain!"));
   console.log(chalk.bold.magenta("Please make sure you have started the server"));

--- a/bin/index.js
+++ b/bin/index.js
@@ -46,7 +46,7 @@ function sendAuditMessage() {
   
   const message = {
     messageType: "CLI_AUDIT_FILE",
-    filePath: bat_sample.audit,
+    filePath: batchain.audit,
   };
   
   console.log("message: ", message);

--- a/constants.js
+++ b/constants.js
@@ -2,7 +2,7 @@ const kad_utils = require('@kadenceproject/kadence/lib/utils');
 
 
 // For network testing:
-exports.SEED_NODE = ['a678ed17938527be1383388004dbf84246505dbd', { hostname: '167.99.2.1', port: 80 }]
+// exports.SEED_NODE = ['a678ed17938527be1383388004dbf84246505dbd', { hostname: '167.99.2.1', port: 80 }]
 
 // For local testing
-//exports.SEED_NODE = ['a678ed17938527be1383388004dbf84246505dbd', { hostname: 'localhost', port: 1338 }]
+exports.SEED_NODE = ['a678ed17938527be1383388004dbf84246505dbd', { hostname: 'localhost', port: 1338 }]

--- a/kad-bat-plugin/batnode.js
+++ b/kad-bat-plugin/batnode.js
@@ -195,10 +195,110 @@ class BatNode {
       })
     })
   }
-  
+
+  auditFile(manifestFilePath) {
+    const manifest = fileUtils.loadManifest(manifestFilePath);
+    const shards = manifest.chunks;
+    const shaIds = Object.keys(shards);
+    const fileName = manifest.fileName;
+    let shaIdx = 0;
+
+    const shardAuditData = shaIds.reduce((acc, shaId) => {
+      acc[shaId] = {};
+
+      shards[shaId].forEach((shardId) => {
+        acc[shaId][shardId] = false;
+      });
+
+      return acc;
+    }, {});
+
+    while (shaIds.length > shaIdx) {
+      this.auditShardsGroup(shards, shaIds, shaIdx, shardAuditData);
+      shaIdx += 1;
+    }
+  }
+  /**
+   * Tests the redudant copies of the original shard for data integrity.
+   * @param {shards} Object - Shard content SHA keys with
+   * array of redundant shard ids
+   * @param {shaIdx} Number - Index of the current
+   * @param {shardAuditData} Object - same as shards param except instead of an
+   * array of shard ids it's an object of shard ids and their audit status
+  */
+  auditShardsGroup(shards, shaIds, shaIdx, shardAuditData) {
+    let shardDupIdx = 0;
+    let duplicatesAudited = 0;
+    const shaId = shaIds[shaIdx];
+
+    while (shards[shaId].length > shardDupIdx) {
+      this.auditShard(shards, shardDupIdx, shaId, shaIdx, shardAuditData);
+      shardDupIdx += 1;
+    }
+  }
+
+  auditShard(shards, shardDupIdx, shaId, shaIdx, shardAuditData) {
+    const shardId = shards[shaId][shardDupIdx];
+
+    this.kadenceNode.iterativeFindValue(shardId, (err, value, responder) => {
+      let kadNodeTarget = value.value;
+      this.kadenceNode.getOtherBatNodeContact(kadNodeTarget, (err, batNode) => {
+        this.auditShardData(batNode, shards, shaIdx, shardDupIdx, shardAuditData)
+      })
+    })
+  }
+
+  auditShardData(targetBatNode, shards, shaIdx, shardDupIdx, shardAuditData) {
+    let client = this.connect(targetBatNode.port, targetBatNode.host);
+
+    const shaKeys = Object.keys(shards);
+    const shaId = shaKeys[shaIdx];
+    const shardId = shards[shaId][shardDupIdx]; // id of a redundant shard for shaId
+
+    const finalShaGroup = shaKeys.length - 1 === shaIdx;
+    const finalShard = shards[shaId].length - 1 === shardDupIdx;
+
+    let message = {
+      messageType: "AUDIT_FILE",
+      fileName: shardId
+    };
+
+    client.write(JSON.stringify(message), (err) => {
+      if (err) { throw err; }
+    })
+
+    client.on('data', (data) => {
+      const hostShardSha1 = data.toString('utf8');
+      // Check that shard content matches original content SHA
+      if (hostShardSha1 === shaId) {
+        shardAuditData[shaId][shardId] = true;
+      }
+
+      if (finalShaGroup && finalShard) {
+        this.auditResults(shardAuditData, shaKeys);
+      }
+    })
+  }
+
+  auditResults(shardAuditData, shaKeys) {
+    const dataValid = shaKeys.every((shaId) => {
+      // For each key in the values object for the shaId key
+      return Object.keys(shardAuditData[shaId]).every((shardId) => {
+        return shardAuditData[shaId][shardId] === true;
+      })
+    });
+    console.log(shardAuditData);
+    if (dataValid) {
+      console.log('Passed audit!');
+    } else {
+      console.log('Failed Audit');
+    }
+  }
+
 }
 
 exports.BatNode = BatNode;
+  
 
 // Upload w/ copy shards
 // Input Data structure: object, keys are the stored filename, value is an array of IDS to associate

--- a/kad-bat-plugin/node1/node1.js
+++ b/kad-bat-plugin/node1/node1.js
@@ -5,7 +5,8 @@ const encoding = require('encoding-down');
 const kad = require('@kadenceproject/kadence');
 const BatNode = require('../batnode.js').BatNode;
 const kad_bat = require('../kadence_plugin').kad_bat;
-const seed = require('../../constants').SEED_NODE
+const seed = require('../../constants').SEED_NODE;
+const fileUtils = require('../../utils/file').fileSystem;
 
 
 // Create first node... Will act as a seed node
@@ -53,6 +54,12 @@ kadnode1.batNode = batnode1 // tell kadnode who its batnode is
           serverConnection.write(JSON.stringify({messageType: "SUCCESS"}))
         })
       })
+    } else if (receivedData.messageType === "AUDIT_FILE") {
+      batnode1.readFile(`./hosted/${receivedData.fileName}`, (error, data) => {
+        const shardSha1 = fileUtils.sha1HashData(data);
+        console.log("shardSha1: ", shardSha1);
+        serverConnection.write(shardSha1);
+      });
     }
   })
 }

--- a/kad-bat-plugin/node2/node2.js
+++ b/kad-bat-plugin/node2/node2.js
@@ -5,7 +5,8 @@ const encoding = require('encoding-down');
 const kad = require('@kadenceproject/kadence');
 const BatNode = require('../batnode.js').BatNode;
 const kad_bat = require('../kadence_plugin').kad_bat;
-const seed = require('../../constants').SEED_NODE
+const seed = require('../../constants').SEED_NODE;
+const fileUtils = require('../../utils/file').fileSystem;
 //console.log(seed)
 
 // Create second batnode kadnode pair
@@ -47,6 +48,12 @@ const nodeConnectionCallback = (serverConnection) => {
           serverConnection.write(JSON.stringify({messageType: "SUCCESS"}))
         })
       })
+    } else if (receivedData.messageType === "AUDIT_FILE") {
+      batnode2.readFile(`./hosted/${receivedData.fileName}`, (error, data) => {
+        const shardSha1 = fileUtils.sha1HashData(data);
+        console.log("shardSha1: ", shardSha1);
+        serverConnection.write(shardSha1);
+      });
     }
   })
 }

--- a/kad-bat-plugin/node3/clinode3.js
+++ b/kad-bat-plugin/node3/clinode3.js
@@ -43,6 +43,12 @@ const nodeCLIConnectionCallback = (serverConnection) => {
 
       batnode3.retrieveFile(filePath);
       batnode3.kadenceNode;
+    } else if (receivedData.messageType === "CLI_AUDIT_FILE") {
+      let filePath = receivedData.filePath;
+      
+      console.log("received path: ", filePath); 
+      batnode3.auditFile(filePath);
+      batnode3.kadenceNode;
     }
   });
 }


### PR DESCRIPTION
In constants.js, I commented out the network testing seed and uncommented the local testing seed. We will need to switch back to network seed by commenting the local seed again.

Note: I only add the audit test in `batnote-sample.js` so you will need to issue the command with `batnode-sample -a <manifestPath>` for the audit test