### PR TITLE
Add transaction for downloading

### DIFF
--- a/batnode.js
+++ b/batnode.js
@@ -11,7 +11,7 @@ const constants = require('./constants');
 
 class BatNode {
   noStellarAccount() {
-    !dotenv.config().parsed.STELLAR_ACCOUNT_ID || !dotenv.config().parsed.STELLAR_SECRET
+    return !dotenv.config().parsed.STELLAR_ACCOUNT_ID || !dotenv.config().parsed.STELLAR_SECRET
   }
 
   constructor(kadenceNode = {}) {
@@ -22,9 +22,10 @@ class BatNode {
         fs.mkdir('./hosted')
       }
     })
-    
+
     if (!fs.existsSync('./.env') || this.noStellarAccount()) {
       let stellarKeyPair = stellar.generateKeys()
+
       fileUtils.generateEnvFile({
         'STELLAR_ACCOUNT_ID': stellarKeyPair.publicKey(),
         'STELLAR_SECRET': stellarKeyPair.secret()
@@ -43,7 +44,6 @@ class BatNode {
     })
 
     this._audit = { ready: false, data: null, passed: false };
-    fileUtils.generateEnvFile()
 
   }
 

--- a/batnode.js
+++ b/batnode.js
@@ -10,10 +10,14 @@ const constants = require('./constants');
 
 
 class BatNode {
+  noStellarAccount() {
+    !dotenv.config().parsed.STELLAR_ACCOUNT_ID || !dotenv.config().parsed.STELLAR_SECRET
+  }
+
   constructor(kadenceNode = {}) {
     this._kadenceNode = kadenceNode;
 
-    if (!fs.existsSync('./.env') || !dotenv.config().parsed.STELLAR_ACCOUNT_ID || !dotenv.config().parsed.STELLAR_SECRET) {
+    if (!fs.existsSync('./.env') || this.noStellarAccount()) {
       let stellarKeyPair = stellar.generateKeys()
       fileUtils.generateEnvFile({
         'STELLAR_ACCOUNT_ID': stellarKeyPair.publicKey(),
@@ -218,7 +222,7 @@ class BatNode {
           this.retrieveSingleCopy(distinctShards, allShards, fileName, manifestFilePath, distinctIdx, copyIdx + 1)
         } else {
           this.kadenceNode.getOtherNodeStellarAccount(kadNode, (error, accountId) => {
-            console.log("The target host returned this stellard id: ", accountId)
+            
             let retrieveOptions = {
               saveShardAs: distinctShards[distinctIdx],
               distinctShards,

--- a/batnode.js
+++ b/batnode.js
@@ -157,7 +157,7 @@ class BatNode {
         })
       });
     } else {
-      console.log("Uploading shards and copies completed! You can safely remove the sahrds files from your end now.")
+      console.log("Uploading shards and copies completed! You can safely remove the files under shards folder from your end now.")
     }
   }
 

--- a/batnode.js
+++ b/batnode.js
@@ -1,6 +1,7 @@
 const tcpUtils = require('./utils/tcp').tcp;
 const fileUtils = require('./utils/file').fileSystem;
 const path = require('path');
+const dotenv = require('dotenv');
 const PERSONAL_DIR = require('./utils/file').PERSONAL_DIR;
 const HOSTED_DIR = require('./utils/file').HOSTED_DIR;
 const fs = require('fs');
@@ -12,7 +13,7 @@ class BatNode {
   constructor(kadenceNode = {}) {
     this._kadenceNode = kadenceNode;
 
-    if (!fs.existsSync('./.env')) {
+    if (!fs.existsSync('./.env') || !dotenv.config().parsed.STELLAR_ACCOUNT_ID || !dotenv.config().parsed.STELLAR_SECRET) {
       let stellarKeyPair = stellar.generateKeys()
       fileUtils.generateEnvFile({
         'STELLAR_ACCOUNT_ID': stellarKeyPair.publicKey(),

--- a/bin/index.js
+++ b/bin/index.js
@@ -10,6 +10,7 @@ const PERSONAL_DIR = require('../utils/file').PERSONAL_DIR;
 const HOSTED_DIR = require('../utils/file').HOSTED_DIR;
 const fileSystem = require('../utils/file').fileSystem;
 const fs = require('fs');
+const CLI_SERVER = require('../constants').CLI_SERVER;
 
 batchain
   .command('sample', 'see the sample nodes running in LAN')
@@ -79,7 +80,7 @@ if (batchain.list) {
   displayFileList();
 
 } else if (batchain.upload) {
-  client = cliNode.connect(1800, 'localhost');  // TODO: change the hard-coded params 
+  client = cliNode.connect(CLI_SERVER.port, CLI_SERVER.host);  
 
   console.log(chalk.yellow('You can only upload one file at a time'));
   
@@ -91,7 +92,7 @@ if (batchain.list) {
   }
 
 } else if (batchain.download) {
-  client = cliNode.connect(1800, 'localhost');  // TODO: change the hard-coded params 
+  client = cliNode.connect(CLI_SERVER.port, CLI_SERVER.host); 
 
   console.log(chalk.yellow('You can only download one file at a time'));
   
@@ -103,7 +104,7 @@ if (batchain.list) {
   }
 
 } else if (batchain.audit) {
-  client = cliNode.connect(1800, 'localhost');
+  client = cliNode.connect(CLI_SERVER.port, CLI_SERVER.host); 
   
   console.log(chalk.yellow('You can audit file to make sure file integrity'));
   

--- a/constants.js
+++ b/constants.js
@@ -1,9 +1,9 @@
 // For network testing:
-// exports.SEED_NODE = ['a678ed17938527be1383388004dbf84246505dbd', { hostname: '167.99.2.1', port: 80 }];
+exports.SEED_NODE = ['a678ed17938527be1383388004dbf84246505dbd', { hostname: '167.99.2.1', port: 80 }];
 exports.CLI_SERVER = {host: 'localhost', port: 1800};
 exports.BATNODE_SERVER_PORT = 1900;
 exports.KADNODE_PORT = 80;
 
 // For local testing
-exports.SEED_NODE = ['a678ed17938527be1383388004dbf84246505dbd', { hostname: 'localhost', port: 1338 }]
+// exports.SEED_NODE = ['a678ed17938527be1383388004dbf84246505dbd', { hostname: 'localhost', port: 1338 }]
 exports.BASELINE_REDUNDANCY = 3;

--- a/constants.js
+++ b/constants.js
@@ -1,9 +1,9 @@
 // For network testing:
-exports.SEED_NODE = ['a678ed17938527be1383388004dbf84246505dbd', { hostname: '167.99.2.1', port: 80 }];
+// exports.SEED_NODE = ['a678ed17938527be1383388004dbf84246505dbd', { hostname: '167.99.2.1', port: 80 }];
 exports.CLI_SERVER = {host: 'localhost', port: 1800};
 exports.BATNODE_SERVER_PORT = 1900;
 exports.KADNODE_PORT = 80;
 
 // For local testing
-// exports.SEED_NODE = ['a678ed17938527be1383388004dbf84246505dbd', { hostname: 'localhost', port: 1338 }]
+exports.SEED_NODE = ['a678ed17938527be1383388004dbf84246505dbd', { hostname: 'localhost', port: 1338 }]
 exports.BASELINE_REDUNDANCY = 3;

--- a/kad-bat-plugin/batnode.js
+++ b/kad-bat-plugin/batnode.js
@@ -1,27 +1,28 @@
 const tcpUtils = require('../utils/tcp').tcp;
 const fileUtils = require('../utils/file').fileSystem;
 const path = require('path');
+const dotenv = require('dotenv');
 const PERSONAL_DIR = require('../utils/file').PERSONAL_DIR;
 const HOSTED_DIR = require('../utils/file').HOSTED_DIR;
 const publicIp = require('public-ip');
+const stellar = require('./utils/stellar').stellar;
 const fs = require('fs');
 
 class BatNode {
+  noStellarAccount() {
+    !dotenv.config().parsed.STELLAR_ACCOUNT_ID || !dotenv.config().parsed.STELLAR_SECRET
+  }
+
   constructor(kadenceNode = {}) {
     this._kadenceNode = kadenceNode;
 
-    // if (!fs.existsSync('./.env')) {
-    //   let stellarKeyPair = stellar.generateKeys()
-    //   fileUtils.generateEnvFile({
-    //     'STELLAR_ACCOUNT_ID': stellarKeyPair.publicKey(),
-    //     'STELLAR_SECRET': stellarKeyPair.secret()
-    //   })
-    // }
-
-    // if env exists but no stellar account
-    let stellarKeyPair = stellar.generateKeys()
-    fileUtils.generateEnvFile({'STELLAR_ACCOUNT_ID': stellarKeyPair.publicKey(),
-    'STELLAR_SECRET': stellarKeyPair.secret()})
+    if (!fs.existsSync('./.env') || this.noStellarAccount()) {
+      let stellarKeyPair = stellar.generateKeys()
+      fileUtils.generateEnvFile({
+        'STELLAR_ACCOUNT_ID': stellarKeyPair.publicKey(),
+        'STELLAR_SECRET': stellarKeyPair.secret()
+      })
+    }
 
     this._stellarAccountId = fileUtils.getStellarAccountId();
 

--- a/kad-bat-plugin/batnode.js
+++ b/kad-bat-plugin/batnode.js
@@ -9,7 +9,35 @@ const fs = require('fs');
 class BatNode {
   constructor(kadenceNode = {}) {
     this._kadenceNode = kadenceNode;
+
+    // if (!fs.existsSync('./.env')) {
+    //   let stellarKeyPair = stellar.generateKeys()
+    //   fileUtils.generateEnvFile({
+    //     'STELLAR_ACCOUNT_ID': stellarKeyPair.publicKey(),
+    //     'STELLAR_SECRET': stellarKeyPair.secret()
+    //   })
+    // }
+
+    // if env exists but no stellar account
+    let stellarKeyPair = stellar.generateKeys()
+    fileUtils.generateEnvFile({'STELLAR_ACCOUNT_ID': stellarKeyPair.publicKey(),
+    'STELLAR_SECRET': stellarKeyPair.secret()})
+
+    this._stellarAccountId = fileUtils.getStellarAccountId();
+
+    stellar.accountExists(this.stellarAccountId, (account) => {
+      console.log('account does exist')
+      account.balances.forEach((balance) =>{
+        console.log('Type:', balance.asset_type, ', Balance:', balance.balance);
+      });
+    }, (publicKey) => {
+      console.log('account does not exist, creating account...')
+      stellar.createNewAccount(publicKey)
+    })
+
+    this._audit = { ready: false, data: null, passed: false };
     fileUtils.generateEnvFile()
+
   }
 
   // TCP server
@@ -74,7 +102,7 @@ class BatNode {
         })
       } else {
         this.distributeCopies(distinctIdx + 1, manifestPath)
-      } 
+      }
     })
 
     client.write(JSON.stringify(message), () => {
@@ -86,7 +114,7 @@ class BatNode {
   uploadFile(filePath, distinctIdx = 0) {
     // Encrypt file and generate manifest
     const fileName = path.parse(filePath).base
-    fileUtils.processUpload(filePath, (manifestPath) => {  
+    fileUtils.processUpload(filePath, (manifestPath) => {
      this.distributeCopies(distinctIdx, manifestPath)
     });
   }
@@ -96,7 +124,7 @@ class BatNode {
     if (distinctIdx < shardsOfManifest.length) {
       const manifest = JSON.parse(fs.readFileSync(manifestPath))
       let copiesOfCurrentShard = manifest.chunks[shardsOfManifest[distinctIdx]]
-  
+
       this.getClosestBatNodeToShard(copiesOfCurrentShard[copyIdx],  (batNode) => {
         this.sendShardToNode(batNode, copiesOfCurrentShard[copyIdx], copiesOfCurrentShard, copyIdx, shardsOfManifest[distinctIdx], distinctIdx, manifestPath)
       });
@@ -298,12 +326,12 @@ class BatNode {
 }
 
 exports.BatNode = BatNode;
-  
+
 
 // Upload w/ copy shards
 // Input Data structure: object, keys are the stored filename, value is an array of IDS to associate
 // with the content of this filename
-// Given a file with the name of <key>, 
+// Given a file with the name of <key>,
 // For each <value id>, read that file's contents and distribute its contents to the
 // appropriate node with the fileName property set to <value id>
 

--- a/kad-bat-plugin/kadence_plugin.js
+++ b/kad-bat-plugin/kadence_plugin.js
@@ -10,7 +10,7 @@ module.exports.kad_bat = function(node) {
     } else {
       res.send(['false'])
     }
-    
+
   });
 
 
@@ -20,3 +20,18 @@ module.exports.kad_bat = function(node) {
   };
 
 };
+
+
+module.exports.stellar_account = function(node) {
+  node.use('STELLAR', (req, res, next) => {
+    let stellarId = node.batNode.stellarAccountId;
+    console.log('my stellar id is: ', stellarId)
+    res.send(`${stellarId}`)
+  })
+
+  node.getOtherNodeStellarAccount = function(targetNode, callback) {
+    console.log('my stellar id is: ', node.batNode.stellarAccountId)
+    console.log("requesting this node's stellar ID: ", targetNode)
+    node.send('STELLAR', [node.batNode.stellarAccountId], targetNode, callback)
+  }
+}

--- a/kad-bat-plugin/node1/node1.js
+++ b/kad-bat-plugin/node1/node1.js
@@ -3,10 +3,11 @@ const levelup = require('levelup');
 const leveldown = require('leveldown');
 const encoding = require('encoding-down');
 const kad = require('@kadenceproject/kadence');
-const BatNode = require('../batnode.js').BatNode;
+const BatNode = require('../../batnode.js').BatNode;
 const kad_bat = require('../kadence_plugin').kad_bat;
 const seed = require('../../constants').SEED_NODE;
 const fileUtils = require('../../utils/file').fileSystem;
+const stellar_account = require('../kadence_plugin').stellar_account;
 
 
 // Create first node... Will act as a seed node
@@ -20,6 +21,7 @@ const kadnode1 = new kad.KademliaNode({
 
 kadnode1.identity = seed[0]
 kadnode1.plugin(kad_bat)
+kadnode1.plugin(stellar_account);
 kadnode1.listen(1338)
 
 

--- a/kad-bat-plugin/node2/node2.js
+++ b/kad-bat-plugin/node2/node2.js
@@ -3,10 +3,11 @@ const levelup = require('levelup');
 const leveldown = require('leveldown');
 const encoding = require('encoding-down');
 const kad = require('@kadenceproject/kadence');
-const BatNode = require('../batnode.js').BatNode;
+const BatNode = require('../../batnode.js').BatNode;
 const kad_bat = require('../kadence_plugin').kad_bat;
 const seed = require('../../constants').SEED_NODE;
 const fileUtils = require('../../utils/file').fileSystem;
+const stellar_account = require('../kadence_plugin').stellar_account;
 //console.log(seed)
 
 // Create second batnode kadnode pair
@@ -19,6 +20,7 @@ const kadnode2 = new kad.KademliaNode({
 
 // Set up
 kadnode2.plugin(kad_bat)
+kadnode2.plugin(stellar_account);
 kadnode2.listen(9000)
 const batnode2 = new BatNode(kadnode2)
 kadnode2.batNode = batnode2

--- a/kad-bat-plugin/node3/clinode3.js
+++ b/kad-bat-plugin/node3/clinode3.js
@@ -3,9 +3,10 @@ const levelup = require('levelup');
 const leveldown = require('leveldown');
 const encoding = require('encoding-down');
 const kad = require('@kadenceproject/kadence');
-const BatNode = require('../batnode.js').BatNode;
+const BatNode = require('../../batnode.js').BatNode;
 const kad_bat = require('../kadence_plugin').kad_bat;
-const seed = require('../../constants').SEED_NODE
+const seed = require('../../constants').SEED_NODE;
+const stellar_account = require('../kadence_plugin').stellar_account;
 
 // Create a third batnode kadnode pair
 
@@ -17,6 +18,7 @@ const kadnode3 = new kad.KademliaNode({
 
 // Set up
 kadnode3.plugin(kad_bat)
+kadnode3.plugin(stellar_account);
 kadnode3.listen(1252)
 const batnode3 = new BatNode(kadnode3)
 kadnode3.batNode = batnode3
@@ -45,8 +47,8 @@ const nodeCLIConnectionCallback = (serverConnection) => {
       batnode3.kadenceNode;
     } else if (receivedData.messageType === "CLI_AUDIT_FILE") {
       let filePath = receivedData.filePath;
-      
-      console.log("received path: ", filePath); 
+
+      console.log("received path: ", filePath);
       batnode3.auditFile(filePath);
       batnode3.kadenceNode;
     }

--- a/kad-bat-plugin/node3/node3.js
+++ b/kad-bat-plugin/node3/node3.js
@@ -5,8 +5,9 @@ const encoding = require('encoding-down');
 const kad = require('@kadenceproject/kadence');
 const BatNode = require('../batnode.js').BatNode;
 const kad_bat = require('../kadence_plugin').kad_bat;
-const seed = require('../../constants').SEED_NODE
+const seed = require('../../constants').SEED_NODE;
 const publicIp = require('public-ip');
+const stellar_account = require('../kadence_plugin').stellar_account;
 
 // Create a third batnode kadnode pair
 
@@ -20,6 +21,7 @@ kadnode3 = new kad.KademliaNode({
 // Set up
 kadnode3.plugin(kad_bat)
 kadnode3.listen(1252)
+kadnode3.plugin(stellar_account);
 const batnode3 = new BatNode(kadnode3)
 kadnode3.batNode = batnode3
 batnode3.createServer(1985, '127.0.0.1')
@@ -29,9 +31,6 @@ batnode3.createServer(1985, '127.0.0.1')
 
 kadnode3.join(seed, () => {
   console.log('you have joined the network! Ready to accept commands from the CLI!')
-  batnode3.uploadFile('./personal/example.txt')
+  // batnode3.uploadFile('./personal/example.txt')
   //batnode3.retrieveFile('./manifest/a8fe349f81906570773853d82b52a8b6bedf2a36.batchain')
 })
-
-
-

--- a/utils/file.js
+++ b/utils/file.js
@@ -26,12 +26,16 @@ exports.fileSystem = (function(){
     if (!fileSystem.existsSync('./.env') || !dotenv.config().parsed.PRIVATE_KEY){
       const privateKey = `PRIVATE_KEY=${generatePrivateKey()}\n`
       envVarsToWrite = envVarsToWrite.concat(privateKey)
-    } 
+    } else {
+      envVarsToWrite = envVarsToWrite.concat(`PRIVATE_KEY=${dotenv.config().parsed.PRIVATE_KEY}\n`)
+    }
+
     if (optionalVars){
       Object.keys(optionalVars).forEach(key => {
         envVarsToWrite = envVarsToWrite.concat(`${key}=${optionalVars[key]}\n`)
       })
     }
+
     if (envVarsToWrite !== ''){
       fileSystem.writeFileSync('./.env', envVarsToWrite)
     }


### PR DESCRIPTION
1. Add transaction for downloading files. Tested locally to make sure transaction works for downloads
2. Add logs for both upload/download to notify if the process completes as adding transaction makes the whole process slower so clients know when to safely remove the shards on their end.