### PR TITLE
Upgrade data patching

### DIFF
--- a/batnode.js
+++ b/batnode.js
@@ -412,7 +412,7 @@ class BatNode {
       const copiesOfSha = Object.keys(auditData[shaKey]);
       copiesOfSha.forEach(shardId => {
         if (auditData[shaKey][shardId] === true){
-          valudShards += 1
+          validShards += 1
         }
       })
       if (validShards < constants.BASELINE_REDUNDANCY){

--- a/batnode.js
+++ b/batnode.js
@@ -410,7 +410,6 @@ class BatNode {
     const isRedundant = (shaId) => {
       let validShards = 0;
       // For each key (shardId) under the shard content's shaId key
-      console.log(auditData, 'audit data')
       Object.keys(auditData[shaId]).forEach((shardId) => {
         if (auditData[shaId][shardId] === true) { validShards += 1; }
       });
@@ -422,12 +421,18 @@ class BatNode {
       }
     }
     shaKeys.every(isRedundant);
+    console.log(auditData, 'audit data')
+    console.log(this.audit.failed, 'this.audit.failed')
     return (this.audit.failed.length === 0)
   }
 
   patchFile(manifestPath, failedShaId, siblingShardId, copiesToRemoveFromManifest) {
 
     // Get siblingShardData
+    // Generate new id with sibling shard data
+    // Find node on the network with closest id to new shard id
+    // Pay that node
+    // Store data on that node
 
     this.getHostNode(siblingShardId, (batNode, kadNode, failed) => {
       if (failed) {
@@ -475,23 +480,6 @@ class BatNode {
         })
       }
     })
-    // Create new ShardId
-    
-
-
-
-    // Should wait for the server to respond with success before starting?
-    /*client.on('data', () => {
-      fs.readFile(manifestPath, (error, manifestData) => {
-        if (error) { throw error; }
-        let manifestJson = JSON.parse(manifestData);
-        manifestJson.chunks[failedShaId].push(newShardId);
-
-        fs.writeFile(manifestPath, JSON.stringify(manifestJson, null, '\t'), (err) => {
-          if (err) { throw err; }
-        });
-      });
-    })*/
   }
 }
 

--- a/batnode.js
+++ b/batnode.js
@@ -409,6 +409,7 @@ class BatNode {
     const isRedundant = (shaId) => {
       let validShards = 0;
       // For each key (shardId) under the shard content's shaId key
+      console.log(auditData, 'audit data')
       Object.keys(auditData[shaId]).forEach((shardId) => {
         if (auditData[shaId][shardId] === true) { validShards += 1; }
       });

--- a/batnode.js
+++ b/batnode.js
@@ -419,10 +419,10 @@ class BatNode {
         return true;
       } else {
         this.audit.failed.push(shaId);
-        return false;
       }
     }
-    return shaKeys.every(isRedundant);
+    shaKeys.every(isRedundant);
+    return (this.audit.failed.length === 0)
   }
 
   patchFile(manifestPath, failedShaId, siblingShardId, copiesToRemoveFromManifest) {

--- a/batnode.js
+++ b/batnode.js
@@ -442,28 +442,34 @@ class BatNode {
   
         client.on('data', (shardData) => {
           const newShardId = fileUtils.createRandomShardId(shardData);
-          this.getClosestBatNodeToShard(newShardId, (closestBatNode) => {
-            let storeMessage = {
-              messageType: "STORE_FILE",
-              fileName: newShardId,
-              fileContent: shardData,
-            }
-            let storeClient = this.connect(closestBatNode.port, closestBatNode.host)
-            storeClient.write(JSON.stringify(storeMessage))
+          this.getClosestBatNodeToShard(newShardId, (closestBatNode, kadNode) => {
 
-            storeClient.on('data', (data) => {
-              fs.readFile(manifestPath, (error, manifestData) => {
-                if (error) { throw error; }
-                let manifestJson = JSON.parse(manifestData);
-                manifestJson.chunks[failedShaId].push(newShardId);
-                manifestJson.chunks[failedShaId] = manifestJson.chunks[failedShaId].filter(id => {
-                  return !copiesToRemoveFromManifest.includes(id)
+            this.kadenceNode.getOtherNodeStellarAccount(kadNode, (error, accountId) => {
+              if (error) {throw error}
+              this.sendPaymentFor(accountId, () => {
+                let storeMessage = {
+                  messageType: "STORE_FILE",
+                  fileName: newShardId,
+                  fileContent: shardData,
+                }
+                let storeClient = this.connect(closestBatNode.port, closestBatNode.host)
+                storeClient.write(JSON.stringify(storeMessage))
+    
+                storeClient.on('data', (data) => {
+                  fs.readFile(manifestPath, (error, manifestData) => {
+                    if (error) { throw error; }
+                    let manifestJson = JSON.parse(manifestData);
+                    manifestJson.chunks[failedShaId].push(newShardId);
+                    manifestJson.chunks[failedShaId] = manifestJson.chunks[failedShaId].filter(id => {
+                      return !copiesToRemoveFromManifest.includes(id)
+                    })
+    
+                    fs.writeFile(manifestPath, JSON.stringify(manifestJson, null, '\t'), (err) => {
+                      if (err) { throw err; }
+                    });
+                  });
                 })
-
-                fs.writeFile(manifestPath, JSON.stringify(manifestJson, null, '\t'), (err) => {
-                  if (err) { throw err; }
-                });
-              });
+              })
             })
           })
         })

--- a/batnode.js
+++ b/batnode.js
@@ -421,7 +421,6 @@ class BatNode {
         return false;
       }
     }
-
     return shaKeys.every(isRedundant);
   }
 

--- a/batnode.js
+++ b/batnode.js
@@ -392,7 +392,6 @@ class BatNode {
         this.audit.data = shardAuditData;
         this.audit.passed = hasBaselineRedundancy;
 
-        console.log(shardAuditData);
         if (hasBaselineRedundancy) {
           console.log('Passed audit!');
         } else {
@@ -407,6 +406,20 @@ class BatNode {
   }
 
   auditResults(auditData, shaKeys) {
+
+    shaKeys.forEach(shaKey => {
+      let validShards = 0;
+      const copiesOfSha = Object.keys(auditData[shaKey]);
+      copiesOfSha.forEach(shardId => {
+        if (auditData[shaKey][shardId] === true){
+          valudShards += 1
+        }
+      })
+      if (validShards < constants.BASELINE_REDUNDANCY){
+        this.audit.failed.push(shaKey)
+      }
+    })
+    /*
     const isRedundant = (shaId) => {
       let validShards = 0;
       // For each key (shardId) under the shard content's shaId key
@@ -420,7 +433,7 @@ class BatNode {
         this.audit.failed.push(shaId);
       }
     }
-    shaKeys.every(isRedundant);
+    shaKeys.every(isRedundant);*/
     console.log(auditData, 'audit data')
     console.log(this.audit.failed, 'this.audit.failed')
     return (this.audit.failed.length === 0)

--- a/bin/index.js
+++ b/bin/index.js
@@ -91,12 +91,14 @@ function findFailedShardCopies(auditData, failedSha){
 async function sendPatchMessage(manifestPath) {
   try {
     const audit = await sendAuditMessage(manifestPath);
-    console.log(audit.data, 'audit.data')
     if (!audit.passed) {
       // patching goes here
-      audit.failed.forEach((failedShaId) => {
+      console.log(audit.failed, 'failed shaIds')
+      let copiesToRemoveFromManifest = []
+      audit.failed.forEach((failedShaId, idx) => {
+        console.log('failed sha from forEach loop', failedShaId)
         const siblingShardId = findRedundantShard(audit.data, failedShaId);
-        const copiesToRemoveFromManifest = findFailedShardCopies(audit.data, failedShaId)
+        copiesToRemoveFromManifest[idx] = findFailedShardCopies(audit.data, failedShaId)
         if (siblingShardId) {
           const message = {
             messageType: "CLI_PATCH_FILE",

--- a/bin/index.js
+++ b/bin/index.js
@@ -81,6 +81,13 @@ function findRedundantShard(auditData, failedSha) {
   return shardKeys.find(isRetrievabalShard);
 }
 
+function findFailedShardCopies(auditData, failedSha){
+  const shardCopiesOfFailedShard = Object.keys(auditData[failedSha]);
+  return shardCopiesOfFailedShard.filter(key => {
+    return auditData[failedSha][key] === false;
+  })
+}
+
 async function sendPatchMessage(manifestPath) {
   try {
     const audit = await sendAuditMessage(manifestPath);
@@ -89,12 +96,14 @@ async function sendPatchMessage(manifestPath) {
       // patching goes here
       audit.failed.forEach((failedShaId) => {
         const siblingShardId = findRedundantShard(audit.data, failedShaId);
+        const copiesToRemoveFromManifest = findFailedShardCopies(audit.data, failedShaId)
         if (siblingShardId) {
           const message = {
             messageType: "CLI_PATCH_FILE",
-            manifestPath: manifestPath,
-            failedShaId: failedShaId,
-            siblingShardId: siblingShardId,
+            manifestPath,
+            failedShaId,
+            siblingShardId,
+            copiesToRemoveFromManifest
           };
 
           console.log('sendPatchMessage - message: ', message);

--- a/bin/index.js
+++ b/bin/index.js
@@ -84,6 +84,7 @@ function findRedundantShard(auditData, failedSha) {
 async function sendPatchMessage(manifestPath) {
   try {
     const audit = await sendAuditMessage(manifestPath);
+    console.log(audit.data, 'audit.data')
     if (!audit.passed) {
       // patching goes here
       audit.failed.forEach((failedShaId) => {

--- a/bin/index.js
+++ b/bin/index.js
@@ -98,7 +98,7 @@ async function sendPatchMessage(manifestPath) {
       audit.failed.forEach((failedShaId, idx) => {
         console.log('failed sha from forEach loop', failedShaId)
         const siblingShardId = findRedundantShard(audit.data, failedShaId);
-        copiesToRemoveFromManifest[idx] = findFailedShardCopies(audit.data, failedShaId)
+        copiesToRemoveFromManifest = copiesToRemoveFromManifest.concat(findFailedShardCopies(audit.data, failedShaId))
         if (siblingShardId) {
           const message = {
             messageType: "CLI_PATCH_FILE",

--- a/start.js
+++ b/start.js
@@ -121,9 +121,15 @@ publicIp.v4().then(ip => {
         sendAuditDataWhenFinished(exponentialBackoff);
 
       } else if (receivedData.messageType === "CLI_PATCH_FILE") {
-        const { manifestPath, siblingShardId, failedShaId } = receivedData;
+        const { manifestPath, siblingShardId, failedShaId, copiesToRemoveFromManifest } = receivedData;
 
-        batNode.getClosestBatNodeToShard(siblingShardId, (hostbatNodeContact) => {
+        // batNode.patchFile(shardData, manifestPath, failedShaId, copiesToRemoveFromManifest)
+        // patchFile should:
+        // 1. generate new shard Id
+        // 2. get closest bat node to new shard id
+        // 3. store file on closest bat node
+        // 4. update manifest
+       /* batNode.getClosestBatNodeToShard(siblingShardId, (hostbatNodeContact) => {
           const { port, host } = hostbatNodeContact;
           const client = batNode.connect(port, host, () => {});
           const message = {
@@ -132,11 +138,12 @@ publicIp.v4().then(ip => {
           };
 
           client.write(JSON.stringify(message));
-
+        
           client.on('data', (shardData) => {
             batNode.patchFile(shardData, manifestPath, failedShaId, hostbatNodeContact)
-          })
-        })
+          })*/
+          batNode.patchFile(manifestPath, failedShaId, siblingShardId, copiesToRemoveFromManifest)
+        //})
       }
     })
   }


### PR DESCRIPTION
Changes I made:

For each failed sha (or distinct shard ID in the manifest), the algorithm will send a patch message. The patch method takes an argument `copiesToRemoveFromManifest`. Patch executes once for each distinct shard ID in the manifest, and `copiesToRemoveFromManifest` includes the copies for the current distinct shard ID in the manifest being patched that actually failed audits. These will be removed from the manifest.

For example, if 2/3 copies failed, for a given distinct shard, then when that shard is patched, 2 copies will be removed. Currently, the patch method always generate 1 extra copy. So, if 2/3 copies of the same shard failed, you'd have to run `patch` twice. I will fix this in an upcoming PR.

I also changed the way `batNode.patchFile` worked. Before, it took a targetBatNode as an argument, and this was supposed to be the batNode on which to store the new shard. The problems with this:
1. This targetBatNode was also the node that supposedly stored the shard duplicate that was retrieved in order to generate a new shard. This guarantees that the new shard will be stored on the same host as one of its duplicates, which makes that node have a higher impact on data redundancy if it fails.
2. This targetBatNode was found with `getClosestBatNodeToShard` which is not the correct way to find a file on the network because it won't guarantee identifying the correct node if another node with an id closer to the file being searched for has joined the network since the time of file upload.



These refactors showed me some great areas that can be refactored to make some of our methods more reusable. Further, it showed me code that is often duplicated that can be extracted into its own methods. This will be the subject of a future PR as well.